### PR TITLE
Support IDs with hyphens; simplify regex slightly.

### DIFF
--- a/src/Hiccup.jl
+++ b/src/Hiccup.jl
@@ -32,9 +32,9 @@ Node(tag::Symbol, content::Node...) = Node(tag, collect(content))
 function cssparse(s)
   trimfirst(s) = s[2:end]
   attrs = Dict()
-  id = match(r"#[A-Za-z0-9]+", s)
+  id = match(r"#-?[_a-zA-Z][_a-zA-Z0-9-]*", s)
   id == nothing || (attrs[:id] = trimfirst(id.match))
-  classes = matchall(r"\.-?[_a-zA-Z]+[_a-zA-Z0-9-]*", s)
+  classes = matchall(r"\.-?[_a-zA-Z][_a-zA-Z0-9-]*", s)
   isempty(classes) || (attrs[:class] = map(trimfirst, classes))
   return attrs
 end


### PR DESCRIPTION
#4 was basically made redundant by #3, except that #3 did not support IDs with hyphens. This mini-pull-request simply updates the ID regex accordingly, and also makes a small (equivalent) simplification to both ID and class regexes.
