### PR TITLE
Support void elements, as per specification http://www.w3.org/TR/html…

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,11 @@ using Hiccup
 using Base.Test
 using Compat
 
+@tags br, link
+
+# hiccup div conflicts with main div, so use this as compromise
+ediv = Hiccup.div
+
 @test contains(sprint(Hiccup.render, Node(:img, "#id.class1.class2", @compat Dict(:src=>"http://www.com"))), "class=\"class1 class2\"")
 
 classMatching = ((".section-title", "section-title"),
@@ -22,3 +27,15 @@ classMatching = ((".section-title", "section-title"),
 for (in, expected) in classMatching
   @test contains(sprint(Hiccup.render, Hiccup.div(in, "contents")), expected)
 end
+
+
+# tests for void tags
+@test string(br()) == "<br />"
+@test string(img(".image-test", [])) == "<img class=\"image-test\" />"
+@test contains(
+  string(link(Dict(:rel => "stylesheet", :href => "test.css"))),
+  "/>")
+@test_throws ArgumentError img(strong(".test", "test"))
+
+# tests for normal tags
+@test string(ediv(ediv(ediv()))) == "<div><div><div></div></div></div>"


### PR DESCRIPTION
…5/syntax.html#void-elementshttp://www.w3.org/TR/html5/syntax.html#void-elements.

By the [html specification](http://www.w3.org/TR/html5/syntax.html#void-elements), we have the following requirement for the elements area, base, br, col, embed, hr, img, input, keygen, link, meta, param, source, track, and wbr:

> Void elements only have a start tag; end tags must not be specified for void elements.

The current version of Hiccup does not render in a way that complies with this requirement.

By the same specification, we have the following requirement:

> Void elements can't have any contents (since there's no end tag, no content can be put between the start tag and the end tag).

The current version of Hiccup allows void elements to have contents.

This pull request disallows contents for void elements by returning an exception if a non-empty list of contents is passed in. It also fixes the rendering for void elements. This change is breaking, but the only applications that would be broken are those which do not comply with the HTML specification. I doubt that many would be using children for `img` or `br` tags in practice anyway, so the disruptive impact is minimal or none.
