### PR TITLE
test 0.3 and 0.4 separately on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.3
+  - 0.4
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
REQUIRE says the package still supports 0.3, would be good to turn travis on so it can be checked
