### PR TITLE
Fix tests on v0.3

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ end
 @test string(br()) == "<br />"
 @test string(img(".image-test", [])) == "<img class=\"image-test\" />"
 @test contains(
-  string(link(Dict(:rel => "stylesheet", :href => "test.css"))),
+  string(link(@compat Dict(:rel => "stylesheet", :href => "test.css"))),
   "/>")
 @test_throws ArgumentError img(strong(".test", "test"))
 


### PR DESCRIPTION
I didn't test my last pull request on v0.3, and I forgot a `@compat`, so the tests were failing on v0.3 (no actual functionality was broken, just the test). This follow-up should fix that.

(Sorry for not checking Travis...)
