### PR TITLE
Fix error in showing attrstring on master

### DIFF
--- a/src/Hiccup.jl
+++ b/src/Hiccup.jl
@@ -62,7 +62,7 @@ export htmlescape
 
 attrstring(xs::Vector) = join(xs, " ")
 attrstring(x) = string(x)
-attrstring(d::Dict) = @as _ d map(t->"$(t[1])=\"$(attrstring(t[2]))\"", _) join(_, " ")
+attrstring(d::Dict) = @as _ d ["$(t[1])=\"$(attrstring(t[2]))\"" for t in _] join(_, " ")
 
 htmlescape(s::AbstractString) =
     @> s replace(r"&(?!(\w+|\#\d+);)", "&amp;") replace("<", "&lt;") replace(">", "&gt;") replace("\"", "&quot;")


### PR DESCRIPTION
On master, `map` on dictionaries now return a dictionary, and Julia gets confused on how strings can be made into a dictionary. I changed it to an array comprehension, and this package works again. Tests (and hence CI) will continue to fail until `Lazy` is fixed also, but I have tested it with a working copy of `Lazy` and all the tests pass.
