### PR TITLE
Unexport div

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Hiccup.jl is a super-simple library designed to make making HTML easy in Julia. 
 ```julia
 julia> using Hiccup
 
-julia> div("#foo.bar", "hi")
+julia> Hiccup.div("#foo.bar", "hi")
 <div class="bar" id="foo">hi</div>
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ julia> Hiccup.div("#foo.bar", "hi")
 HTML nodes are stored as the `Node{T}` type which renders itself smartly.
 
 ```julia
-julia> Node(:img, "#id.class1.class2", [:src=>"http://www.com"])
-<img class="class1 class2" src="http://www.com" id="id"></img>
+julia> Node(:img, "#id.class1.class2", Dict(:src=>"http://www.com"))
+<img src="http://www.com" id="id" class="class1 class2" />
 
 julia> tag(ans)
 :img
@@ -28,7 +28,7 @@ A bunch of utility functions, with the names of tags, are provided which make th
 ```julia
 julia> @tags img, svg
 
-julia> svg("#id.class1.class2", [:src=>"http://www.com"])
+julia> svg("#id.class1.class2", Dict(:src=>"http://www.com"))
 <svg class="class1 class2" src="http://www.com" id="id"></svg>
 ```
 

--- a/src/Hiccup.jl
+++ b/src/Hiccup.jl
@@ -115,12 +115,18 @@ macro exporttags(ts)
   end
 end
 
-@exporttags div, span, a,
+@exporttags span, a,
             h1, h2, h3,
             html, head, body,
             pre, code,
             img, style,
             ol, ul, li, table, tr, td,
             strong
+
+if VERSION < v"0.4"
+  @exporttags div
+else
+  @tags div
+end
 
 end # module


### PR DESCRIPTION
On Julia v0.4+, this export does nothing except create a warning. I had to keep the tag because downstream packages, such as Mux, depended on it. This change does not affect v0.3.

The second commit is unrelated—it just updates the README to use newer dict syntax, and fixes the output of one img tag (which is a void element). I can open another PR if needed, but I thought it was minor enough to put as a footnote for this one.

Closes #10.
