### PR TITLE
Fix deprecation warning on v0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.3
 Lazy
 MacroTools
-Compat
+Compat 0.8.2

--- a/src/Hiccup.jl
+++ b/src/Hiccup.jl
@@ -88,9 +88,9 @@ function render(io::IO, xs::Vector)
   end
 end
 
-render(io::IO, x) = writemime(io, MIME"text/html"(), x)
+render(io::IO, x) = @compat show(io, MIME"text/html"(), x)
 
-Base.writemime(io::IO, ::MIME"text/html", node::Node) = render(io, node)
+@compat Base.show(io::IO, ::MIME"text/html", node::Node) = render(io, node)
 
 Base.show(io::IO, node::Node) = render(io, node)
 


### PR DESCRIPTION
Uses Compat's new show rewriting to fix a deprecation warning on v0.5. Bumped Compat dependency.

This is the last warning :smiley:! Now loads without a hiccup (ha!) on v0.5.
