### PR TITLE
Escape attribute strings, other misc escaping fixes

### DIFF
--- a/src/Hiccup.jl
+++ b/src/Hiccup.jl
@@ -60,12 +60,13 @@ Node(tag::Symbol, selector::AbstractString, content, args...; kws...) =
 
 export htmlescape
 
-attrstring(xs::Vector) = join(xs, " ")
-attrstring(x) = string(x)
-attrstring(d::Dict) = @as _ d ["$(t[1])=\"$(attrstring(t[2]))\"" for t in _] join(_, " ")
-
 htmlescape(s::AbstractString) =
-    @> s replace(r"&(?!(\w+|\#\d+);)", "&amp;") replace("<", "&lt;") replace(">", "&gt;") replace("\"", "&quot;")
+  @> s replace("&", "&amp;") replace("<", "&lt;") replace(">", "&gt;")
+
+attrstring(xs::Vector) = join(xs, " ")
+attrstring(x) =
+  @> x string htmlescape replace("\"", "&quot;") replace("'", "&#39;")
+attrstring(d::Dict) = @as _ d ["$(t[1])=\"$(attrstring(t[2]))\"" for t in _] join(_, " ")
 
 render(io::IO, s::AbstractString) = print(io, htmlescape(s))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,3 +39,10 @@ end
 
 # tests for normal tags
 @test string(ediv(ediv(ediv()))) == "<div><div><div></div></div></div>"
+
+# test escapes
+@test string(Node(:pre, "<p>fish &amp; chips</p>")) ==
+  "<pre>&lt;p&gt;fish &amp;amp; chips&lt;/p&gt;</pre>"
+
+@test string(Node(:a, "link", href="http://example.com/test?a&b")) ==
+  "<a href=\"http://example.com/test?a&amp;b\">link</a>"


### PR DESCRIPTION
Breakdown of this change:
- Escape all `&`, not just `&` not used in escape sequences. Not escaping escape sequences like `&amp;` is confusing and inconsistent, and is prone to causing user bugs. Also, new behaviour matches that of "upstream" (Clojure Hiccup).
- No need to escape `"` outside attribute strings.
- Escape attribute strings. Not escaping them was a bug at best and a security (XSS) risk at worst.

Overall, I think the resulting behaviour is less surprising. The first change is potentially breaking, but I don't know of any real application of the old behaviour.
