### PR TITLE
Turn on precompilation, remove unnecessary version check.

### DIFF
--- a/src/Hiccup.jl
+++ b/src/Hiccup.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module Hiccup
 
 using MacroTools, Compat
@@ -128,10 +129,6 @@ end
             ol, ul, li, table, tr, td,
             strong
 
-if VERSION < v"0.4"
-  @exporttags div
-else
-  @tags div
-end
+@tags div
 
 end # module


### PR DESCRIPTION
I think precompilation can be turned on safely. Also, REQUIRE has a minimum of julia 0.5, so the version check is not needed. I'd appreciate a new release tag if you decide you'd like to merge so that I can use this in one of my precompiled packages.